### PR TITLE
Optics 2022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
 
-## IN PROGRESS Version 0.1.0
+## 2024-04-05 Version 0.1.0
 
 - Added:
   - new (>2022) lhc orbit variabes and related changes in corresponding functions
   - flexible knob-suffix instead of pre-defined "_sq"
-  - new functions: `temp_disable_errors` and `lhc_arc_names` in `general.py`
+  - new functions: `temp_disable_errors`, `lhc_arc_names` and `add_expression` in `general.py`
   - Coupling knob creation
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+
+## IN PROGRESS Version 0.1.0
+
+- Added:
+  - new (>2022) lhc orbit variabes and related changes in corresponding functions
+  - flexible knob-suffix instead of pre-defined "_sq"
+  - new functions: `temp_disable_errors` and `lhc_arc_names` in `general.py`
+  - Coupling knob creation
+
+
+## 2022-03-22 Version 0.0.2
+
+- typo magentic to magnetic
+- more doc
+- unified `machine` -> `accel`
+- some minor fixes of copy-paste remains
+
+
+## 2021-11-19 Version 0.0.1
+
+- This is a very early release. Thinks should work, but I need tests.

--- a/cpymad_lhc/__init__.py
+++ b/cpymad_lhc/__init__.py
@@ -1,7 +1,7 @@
 __title__ = "cpymad-lhc"
 __description__ = "Helper functions to run LHC optics in cpymad"
 __url__ = "https://github.com/JoschD/cpymad_lhc"
-__version__ = "0.0.3"
+__version__ = "0.1.0"
 __author__ = "JoschD"
 __author_email__ = "JoschD@github.com"
 __license__ = "MIT"

--- a/cpymad_lhc/__init__.py
+++ b/cpymad_lhc/__init__.py
@@ -1,7 +1,7 @@
 __title__ = "cpymad-lhc"
 __description__ = "Helper functions to run LHC optics in cpymad"
 __url__ = "https://github.com/JoschD/cpymad_lhc"
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 __author__ = "JoschD"
 __author_email__ = "JoschD@github.com"
 __license__ = "MIT"

--- a/cpymad_lhc/corrector_limits.py
+++ b/cpymad_lhc/corrector_limits.py
@@ -14,7 +14,7 @@ import logging
 
 from cpymad.madx import Madx
 
-from cpymad_lhc.general import _all_arcs
+from cpymad_lhc.general import lhc_arc_names
 
 LOG = logging.getLogger(__name__)
 LOG_FORMAT = "{name:<10s}    {val_str:>10s}    {max_str:>10s}    {allowed_str:>10s}"
@@ -108,14 +108,14 @@ class LimitChecks:
         """ Loop over arcs """
         fd_list = 'FD' if family in FD_FAMILIES else ['']
         num_list = '12' if family in TWO_FAMILIES else ['']
-        for arc in _all_arcs(self.beam):
+        for arc in lhc_arc_names(self.beam):
             for fd in fd_list:
                 for num in num_list:
                     self.check_strength(f'K{family[1:]}{fd}{num}.{arc}', value)
 
     def check_special(self, family, value):
         """ Loop over arcs but only every second one. """
-        arcs = _all_arcs(self.beam)[(self.beam % 2)::2]
+        arcs = lhc_arc_names(self.beam)[(self.beam % 2)::2]
         for arc in arcs:
             self.check_strength(f'K{family[1:]}.{arc}', value)
             self.check_strength(f'K{family[1:]}.L{arc[1]}B{self.beam:d}', value)

--- a/cpymad_lhc/coupling_correction.py
+++ b/cpymad_lhc/coupling_correction.py
@@ -17,7 +17,7 @@ LOG = logging.getLogger(__name__)
 
 
 def correct_coupling(madx: Madx, accel: str, sequence: str,
-                     squeezed: bool = False, **kwargs):
+                     knobs_suffix: str = "", **kwargs):
     """ Wrapper for coupling correction to use the default knob-names if not
      otherwise given.
 
@@ -25,7 +25,7 @@ def correct_coupling(madx: Madx, accel: str, sequence: str,
         madx: Madx instance
         accel: Accelerator we are using 'LHC' or 'HLLHC'
         sequence: Sequence to use
-        squeezed: Use squeezed knobs (`_sq`)
+        knobs_suffix: Use suffix with knobs ( e.g. `_sq`)
 
     Keyword Args:
         Other arguments of `correct_coupling_with_knobs`
@@ -35,11 +35,9 @@ def correct_coupling(madx: Madx, accel: str, sequence: str,
         if len(not_defined):
             raise KeyError(f"Knobs {not_defined} are not defined in sequence!")
 
-    knobs_dict = _get_default_knob_names(accel, sequence)
+    knobs_dict = _get_default_knob_names(accel, sequence, suffix=knobs_suffix)
     for knob_arg, knob_names in knobs_dict.items():
         if knob_arg not in kwargs:
-            if squeezed:
-                knob_names = tuple(f"{k}_sq" for k in knob_names)
             check_knobs(knob_names)
             kwargs[knob_arg] = knob_names
 
@@ -139,10 +137,10 @@ def _get_middle_tunes(qx: float, qy: float) -> Tuple[float, float]:
     return qx_mid, qy_mid
 
 
-def _get_default_knob_names(accel: str, sequence: str) -> dict:
+def _get_default_knob_names(accel: str, sequence: str, suffix: str = "") -> dict:
     """ Get tune, chroma and coupling knobs. """
-    tune_chroma_knobs = list(get_tune_and_chroma_knobs(accel, int(sequence[-1])))
-    coupling_knobs = list(get_coupling_knobs(accel, int(sequence[-1])))
+    tune_chroma_knobs = list(get_tune_and_chroma_knobs(accel, int(sequence[-1]), suffix=suffix))
+    coupling_knobs = list(get_coupling_knobs(accel, int(sequence[-1]), suffix=suffix))
     return dict(tune_knobs=tune_chroma_knobs[:2],
                 chroma_knobs=tune_chroma_knobs[2:],
                 coupling_knobs=coupling_knobs)

--- a/cpymad_lhc/coupling_knob.py
+++ b/cpymad_lhc/coupling_knob.py
@@ -13,7 +13,7 @@ from typing import Sequence, Union
 # from optics_functions.coupling import coupling_via_cmatrix
 import pandas as pd
 from cpymad.madx import Madx
-from cpymad_lhc.general import lhc_arcs, get_coupling_knobs, get_tfs
+from cpymad_lhc.general import lhc_arcs, get_coupling_knobs, get_tfs, add_expression
 import numpy as np
 import tfs
 
@@ -197,10 +197,10 @@ def create_coupling_knobs(madx: Madx, beam: int, accel: str, optics: Union[Path,
         mvars[coeff_name_real] = coeff_real
         mvars[coeff_name_imag] = coeff_imag
 
-        definition_str = f"{coeff_real} * {knob_name_real} + {coeff_imag} * {knob_name_imag}"
+        definition_str = f"{coeff_name_real} * {knob_name_real} + {coeff_name_imag} * {knob_name_imag}"
 
         if sector in SINGLE_KQS_LISTS[beam]:
-            mvars[f"kqs.a{sector}b{beam}"] = definition_str
+            add_expression(madx, f"kqs.a{sector}b{beam}", definition_str)
         else:
-            mvars[f"kqs.r{sector[0]}b{beam}"] = definition_str
-            mvars[f"kqs.l{sector[1]}b{beam}"] = definition_str
+            add_expression(madx, f"kqs.r{sector[0]}b{beam}", definition_str)
+            add_expression(madx, f"kqs.l{sector[1]}b{beam}", definition_str)

--- a/cpymad_lhc/coupling_knob.py
+++ b/cpymad_lhc/coupling_knob.py
@@ -7,12 +7,15 @@ Not implemented yet. TODO!
 """
 
 from operator import itemgetter
-from typing import Sequence
+from pathlib import Path
+from typing import Sequence, Union
 
 # from optics_functions.coupling import coupling_via_cmatrix
 import pandas as pd
 from cpymad.madx import Madx
+from cpymad_lhc.general import lhc_arcs, get_coupling_knobs, get_tfs
 import numpy as np
+import tfs
 
 import logging
 
@@ -63,3 +66,141 @@ def get_attribute_response(madx: Madx, sequence: str, variables: Sequence[str], 
     # drop all-zero rows
     df = df.loc[(df!=0).any(axis=1)]
     return df
+
+
+# Old-School Coupling Knobs -------------------
+SINGLE_KQS_LISTS = {
+# Sectors with commonly powered MQSs
+    1: ['23', '45', '67', '81'],
+    2: ['12', '34', '56', '78'], 
+}
+
+
+def calculate_coupling_coefficients_per_sector(
+        df: tfs.TfsDataFrame, 
+        deactivate_sectors: Sequence[str] = ('12', '45', '56', '81')
+    ) -> tfs.TfsDataFrame:
+    """ Calculate the coupling knob coefficients as in corr_MB_ats_v4.
+    This is basically Eq. (59) in https://cds.cern.ch/record/522049/files/lhc-project-report-501.pdf ,
+    with cosine for the real part and sine for the imaginary part.
+    What is happening here is, that we are building a matrix for the equation-system
+    M * [MQS12,..., MQS81] = -[RE, IM]
+    where RE and IM are the real and imaginary parts of the coupling coefficients, 
+    and therefore the knobs we want to create.
+    MQS12 - MQS81 is the total powering of the MQS per arc, which we steer with 
+    the knob. All MQS in a single arc are assumed to be powered equally.
+    After building the matrix, we "solve" the equation system via pseudo-inverese M+
+    and get therefore the definition of the coupling knob.
+    [MQS12,..., MQS81] = - M+ * [RE, IM]
+    HINT: The MINN function in corr_MB_ats_v4 is simply the calculation the pseudo-inverse:
+    M+  = M' (M * M')^-1  (' = transpose, ^-1 = inverse)
+    including the minus on the rhs of the equation.
+    TODO:
+        - Get beta and phases from the beamline directly (instead of the TFS dataframe)
+        - Make the number of MQS more flexible, could maybe be parsed from the beamline
+        - Why is there an absolute value in Eq. (59) but not in the code? (see also https://cds.cern.ch/record/2778887/files/CERN-ACC-NOTE-2021-0022.pdf)
+        - Add a2 correction to the KQS definition (as in corr_MB_ats_v4)
+        - Include the actual fractional tune split of the current machine (see also https://cds.cern.ch/record/2778887/files/CERN-ACC-NOTE-2021-0022.pdf)
+        - Calculate also the contribution to f_1010 and try to set to zero
+        - Does this still work when slicing the MQS?
+    Args:
+        df (tfs.TfsDataFrame): 
+            Dataframe containing the optics of the machine. 
+        deactivate_sectors (Sequence[str], optional): 
+            Deactivate these sectors, i.e. don't use their MQS. 
+            Defaults to ('12', '45', '56', '81'), the ATS sectors.
+    """
+    BETX, BETY, MUX, MUY = "BETX", "BETY", "MUX", "MUY"
+    MQS_PER_SECTOR = 4  # TODO: get from line (?)
+    LENGTH_MQS = 0.32  # TODO: get from l.mqs
+
+    sectors = lhc_arcs()
+
+    mqs_sectors = [fr"MQS\..*(R{s[0]}|L{s[1]})\.B" for s in sectors]
+    m = np.ndarray([2, len(sectors)])
+
+    for idx_sector, mqs_regex in enumerate(mqs_sectors):
+        sector_mqs_slices = df.index.str.match(mqs_regex)
+        df_mqs = df.loc[sector_mqs_slices]
+
+        contribution_per_slice = MQS_PER_SECTOR / len(df_mqs)  # Knobs are not automatically normalized on slicing?
+        coeff = contribution_per_slice * np.sqrt(df_mqs[BETX] * df_mqs[BETY])
+        phase = 2*np.pi * (df_mqs[MUX] - df_mqs[MUY])
+
+        for idx, fun in enumerate((np.cos, np.sin)):
+            m[idx, idx_sector] =  (coeff * fun(phase)).sum() 
+
+    m = m * LENGTH_MQS  / (2 * np.pi)  # kqs knobs are multiplied by the length of the MQS
+
+    if deactivate_sectors:
+        mask = [s in deactivate_sectors for s in sectors]
+        m[: , mask] = 0
+
+    result = tfs.TfsDataFrame(
+        data=-np.linalg.pinv(m),
+        index=sectors, 
+        columns=["re", "im"]
+    )
+
+    # remove numerical noise:
+    result = result.where(result.abs() > 1e-15, 0)
+
+    return result
+
+
+def create_coupling_knobs(madx: Madx, beam: int, accel: str, optics: Union[Path, tfs.TfsDataFrame] = None):
+    """ Create coupling knobs in the beam-line.
+    WARNING: This function will not take a2 errors into account! 
+    Normally, the a2 errors are also corrected with the MQS, but in this function 
+    the MQS powering is fully controlled by the coupling knobs. 
+    See also the todo's in :func:`xmask.lhc.knob_manipulations.calculate_coupling_coefficients_per_sector`
+    Args:
+        madx (Madx): Madx instance to incorporate the knobs in
+        beam (int): Beam number.
+        optics (Path, tfs.TfsDataFrame, optional): 
+            Path or TfsDataFrame of the twiss containing the optics to be used. 
+            If not given, a twiss will be computed. Defaults to None.
+    """
+    LOG.info(f"Creating Coupling Knobs for beam {beam} ---")
+    mvars = madx.globals
+
+    if beam == 4:
+        beam = 2  # same behaviour in this case
+
+    beam_sign = 1 if beam == 1 else -1
+
+
+    if optics is None:
+        madx.twiss()
+        df = get_tfs(madx.table.twiss)
+    elif isinstance(optics, Path):
+        df = tfs.read(optics, index="NAME")
+    else:
+        df = optics
+
+    assert int(df.headers["SEQUENCE"][-1]) == beam, f"Wrong optics file for beam {beam}!"
+
+    df = beam_sign * calculate_coupling_coefficients_per_sector(df)
+
+    knob_name_real, knob_name_imag = get_coupling_knobs(accel, beam)
+
+    mvars[knob_name_real] = 0
+    mvars[knob_name_imag] = 0
+
+    for sector in df.index:
+        coeff_real = df.loc[sector, "re"]
+        coeff_imag = df.loc[sector, "im"]
+
+        coeff_name_real = f"coeff_skew_re_arc{sector}_b{beam}"
+        coeff_name_imag = f"coeff_skew_im_arc{sector}_b{beam}"
+
+        mvars[coeff_name_real] = coeff_real
+        mvars[coeff_name_imag] = coeff_imag
+
+        definition_str = f"{coeff_real} * {knob_name_real} + {coeff_imag} * {knob_name_imag}"
+
+        if sector in SINGLE_KQS_LISTS[beam]:
+            mvars[f"kqs.a{sector}b{beam}"] = definition_str
+        else:
+            mvars[f"kqs.r{sector[0]}b{beam}"] = definition_str
+            mvars[f"kqs.l{sector[1]}b{beam}"] = definition_str

--- a/cpymad_lhc/general.py
+++ b/cpymad_lhc/general.py
@@ -577,6 +577,25 @@ def get_k_strings(start: int = 0, stop: int = 8, orientation: str = 'both'):
     return [f"K{i:d}{s:s}L" for i in range(start, stop) for s in orientation]
 
 
+def add_expression(madx: Madx, name: str, expression: str):
+    """ Add an expression to a variable that might already 
+    be a deferred expression. 
+
+    Args:
+        madx (Madx): Madx instance to incorporate the variable in
+        name (str): Name of the variable
+        expression (str): Expression to assign
+    """
+    try:
+        old_expression = madx.globals.cmdpar[name].expr
+    except KeyError:
+        old_expression = None
+
+    if old_expression is not None:
+        expression = f"{old_expression} + {expression}"
+    madx.globals[name] = expression
+
+
 @contextmanager
 def temp_disable_errors(madx: Madx, *args):
     """ Disable all global variable args and restore their value afterwards."""

--- a/cpymad_lhc/ir_orbit.py
+++ b/cpymad_lhc/ir_orbit.py
@@ -25,7 +25,7 @@ X Crossing offsets - opposite sign (i.e. same sides)
 Y Separation - opposite sign (i.e. opposite sides)
 """
 import re
-from typing import Iterable, Union
+from typing import Iterable, Union, Dict
 
 from cpymad.madx import Madx
 from pandas import DataFrame
@@ -38,56 +38,72 @@ from cpymad_lhc.general import get_tfs
 LOG = logging.getLogger(__name__)
 
 
-CROSSING_SCHEMES = {  # from tracking masks
-    'flat': {},
-    'lhc_inj': {
-        'on_x1':  170, 'on_sep1': -2,
-        'on_x2':  170, 'on_sep2': 3.5,
-        'on_x5':  170, 'on_sep5': 2,
-        'on_x8': -170, 'on_sep8': -3.5,
-        'phi_ir1': 90, 'phi_ir5': 0,
-        'phi_ir2': 90, 'phi_ir8': 180,
-    },
-    'lhc_top': {
-        'on_x1':  160, 'on_sep1': -0.55,
-        'on_x2':  200, 'on_sep2': 1.4,
-        'on_x5':  160, 'on_sep5': 0.55,
-        'on_x8': -250, 'on_sep8': -1,
-        'phi_ir1': 90, 'phi_ir5': 0,
-        'phi_ir2': 90, 'phi_ir8': 180,
-    },
-    'lhc2022_top': {
-        'on_x1_v': -160, 'on_sep1_h': -0.55,
-        'on_x1_h':    0, 'on_sep1_v':  0.0,
-        'on_x2v':   200, 'on_sep2h':   1.0,
-        'on_x2h':     0, 'on_sep2v':   0.0,
-        'on_x5_h':  160, 'on_sep5_v':  0.55,
-        'on_x5_v':    0, 'on_sep5_h':  0.0,
-        'on_x8h':  -200, 'on_sep8v':  -1.0,
-        'on_x8v':     0, 'on_sep8h':   0.0,
-    },
-    'hllhc_inj': {
-        'on_x1':  295, 'on_sep1': -2,
-        'on_x2':  170, 'on_sep2': 3.5, 'on_a2': -40,
-        'on_x5':  295, 'on_sep5': 2,
-        'on_x8': -170, 'on_sep8': -3.5, 'on_a8': -40,
-        'on_crab1': 0, 'on_crab5': 0,
-        'phi_ir1': 0, 'phi_ir5': 90,
-        'phi_ir2': 90, 'phi_ir8': 0,
-    },
-    'hllhc_top': {
-        'on_x1':  250, 'on_sep1': -0.75,
-        'on_x2':  170, 'on_sep2': 1,
-        'on_x5':  250, 'on_sep5': 0.75,
-        'on_x8': -200, 'on_sep8': -1,
-        'on_crab1': -190, 'on_crab5': -190,
-        'phi_ir1': 0, 'phi_ir5': 90,
-        'phi_ir2': 90, 'phi_ir8': 0,
-    },
-}
+def crossing_schemes(scheme: str, accel: str, year: int = 2018) -> Dict[str, float]:  # from tracking masks
+    if scheme == 'flat':
+        return {}
+
+    if accel == 'lhc':
+        # Old crossing variables before run III
+        if year < 2020:
+            return{
+                'inj': {
+                    'on_x1':  170, 'on_sep1': -2,
+                    'on_x2':  170, 'on_sep2': 3.5,
+                    'on_x5':  170, 'on_sep5': 2,
+                    'on_x8': -170, 'on_sep8': -3.5,
+                    'phi_ir1': 90, 'phi_ir5': 0,
+                    'phi_ir2': 90, 'phi_ir8': 180,
+                },
+                'top': {
+                    'on_x1':  160, 'on_sep1': -0.55,
+                    'on_x2':  200, 'on_sep2': 1.4,
+                    'on_x5':  160, 'on_sep5': 0.55,
+                    'on_x8': -250, 'on_sep8': -1,
+                    'phi_ir1': 90, 'phi_ir5': 0,
+                    'phi_ir2': 90, 'phi_ir8': 180,
+                },
+            }[scheme]
+
+        # New crossing variables since run III
+        return {
+            'top': {
+                'on_x1_v': -160, 'on_sep1_h': -0.55,
+                'on_x1_h':    0, 'on_sep1_v':  0.0,
+                'on_x2v':   200, 'on_sep2h':   1.0,
+                'on_x2h':     0, 'on_sep2v':   0.0,
+                'on_x5_h':  160, 'on_sep5_v':  0.55,
+                'on_x5_v':    0, 'on_sep5_h':  0.0,
+                'on_x8h':  -200, 'on_sep8v':  -1.0,
+                'on_x8v':     0, 'on_sep8h':   0.0,
+            },
+        }[scheme]    
+
+    elif accel == 'hllhc':
+        return {
+            'inj': {
+                'on_x1':  295, 'on_sep1': -2,
+                'on_x2':  170, 'on_sep2': 3.5, 'on_a2': -40,
+                'on_x5':  295, 'on_sep5': 2,
+                'on_x8': -170, 'on_sep8': -3.5, 'on_a8': -40,
+                'on_crab1': 0, 'on_crab5': 0,
+                'phi_ir1': 0, 'phi_ir5': 90,
+                'phi_ir2': 90, 'phi_ir8': 0,
+            },
+            'top': {
+                'on_x1':  250, 'on_sep1': -0.75,
+                'on_x2':  170, 'on_sep2': 1,
+                'on_x5':  250, 'on_sep5': 0.75,
+                'on_x8': -200, 'on_sep8': -1,
+                'on_crab1': -190, 'on_crab5': -190,
+                'phi_ir1': 0, 'phi_ir5': 90,
+                'phi_ir2': 90, 'phi_ir8': 0,
+            },
+        }[scheme]
+
+    raise KeyError(f"Unknown crossing scheme: {scheme}")
 
 
-def get_orbit_variables(accel: str, year: int = 2022):
+def get_orbit_variables(accel: str, year: int = 2018):
     """ Get the variable names used for orbit setup.
     Args:
         accel (str): 'lhc' or 'hllhc'
@@ -171,15 +187,7 @@ def orbit_setup(madx: Madx, accel: str, year: int = 2018, **kwargs):
 
     if scheme_key is not None:
         default = 0
-        for key in (f'{accel.lower()}_{scheme_key.lower()}' , scheme_key.lower()):
-            try:
-                scheme = CROSSING_SCHEMES[key]
-            except KeyError:
-                pass
-            else:
-                break
-        else:
-            raise KeyError(f"Scheme '{scheme_key}' not recognized.")
+        scheme = crossing_schemes(scheme=key, accel=accel, year=year)
 
     for var in variables:
         set_value(var, kwargs.get(var, scheme.get(var, default)))

--- a/cpymad_lhc/ir_orbit.py
+++ b/cpymad_lhc/ir_orbit.py
@@ -187,7 +187,7 @@ def orbit_setup(madx: Madx, accel: str, year: int = 2018, **kwargs):
 
     if scheme_key is not None:
         default = 0
-        scheme = crossing_schemes(scheme=key, accel=accel, year=year)
+        scheme = crossing_schemes(scheme=scheme_key, accel=accel, year=year)
 
     for var in variables:
         set_value(var, kwargs.get(var, scheme.get(var, default)))

--- a/cpymad_lhc/ir_orbit.py
+++ b/cpymad_lhc/ir_orbit.py
@@ -56,6 +56,16 @@ CROSSING_SCHEMES = {  # from tracking masks
         'phi_ir1': 90, 'phi_ir5': 0,
         'phi_ir2': 90, 'phi_ir8': 180,
     },
+    'lhc2022_top': {
+        'on_x1_v': -160, 'on_sep1_h': -0.55,
+        'on_x1_h':    0, 'on_sep1_v':  0.0,
+        'on_x2v':   200, 'on_sep2h':   1.0,
+        'on_x2h':     0, 'on_sep2v':   0.0,
+        'on_x5_h':  160, 'on_sep5_v':  0.55,
+        'on_x5_v':    0, 'on_sep5_h':  0.0,
+        'on_x8h':  -200, 'on_sep8v':  -1.0,
+        'on_x8v':     0, 'on_sep8h':   0.0,
+    },
     'hllhc_inj': {
         'on_x1':  295, 'on_sep1': -2,
         'on_x2':  170, 'on_sep2': 3.5, 'on_a2': -40,
@@ -77,10 +87,11 @@ CROSSING_SCHEMES = {  # from tracking masks
 }
 
 
-def get_orbit_variables(accel: str):
+def get_orbit_variables(accel: str, year: int = 2022):
     """ Get the variable names used for orbit setup.
     Args:
         accel (str): 'lhc' or 'hllhc'
+        year (int): year of the models/optics (for 'lhc')
 
     Returns:
         tuple of 0: list of all orbit variables, apart form those in 1
@@ -99,27 +110,38 @@ def get_orbit_variables(accel: str):
         )
         special = {}
     else:
-        on_variables = (
-            'x1', 'sep1', 'o1', 'oh1', 'ov1',
-            'x2', 'sep2', 'o2', 'oe2', 'a2', 'oh2', 'ov2',
-            'x5', 'sep5', 'o5', 'oh5', 'ov5',
-            'x8', 'sep8', 'o8', 'a8', 'sep8h', 'x8v', 'oh8', 'ov8',
-            'alice', 'sol_alice', 'lhcb', 'sol_atlas', 'sol_cms',
-        )
-        special = {'on_ssep1': 'on_sep1', 'on_xx1': 'on_x1',
-                   'on_ssep5': 'on_sep5', 'on_xx5': 'on_x5',
-                   }
+        if year < 2020:
+            on_variables = (
+                'x1', 'sep1', 'o1', 'oh1', 'ov1',
+                'x2', 'sep2', 'o2', 'oe2', 'a2', 'oh2', 'ov2',
+                'x5', 'sep5', 'o5', 'oh5', 'ov5',
+                'x8', 'sep8', 'o8', 'a8', 'sep8h', 'x8v', 'oh8', 'ov8',
+                'alice', 'sol_alice', 'lhcb', 'sol_atlas', 'sol_cms',
+            )
+            special = {'on_ssep1': 'on_sep1', 'on_xx1': 'on_x1',
+                       'on_ssep5': 'on_sep5', 'on_xx5': 'on_x5',
+                       }
+        else:
+            on_variables = (
+                'x1_v', 'sep1_v', 'x1_h', 'sep1_h',
+                'x5_v', 'sep5_v', 'x5_h', 'sep5_h',
+                'x2v', 'sep2v', 'x2h', 'sep2h', 'o2', 'a2', 'oh2', 'ov2',
+                'x8v', 'sep8v', 'x8h', 'sep8h', 'o8', 'a8', 'oh8', 'ov8',
+                'alice', 'sol_alice', 'lhcb', 'sol_atlas', 'sol_cms',
+            )
+            special = dict()
     variables = [f'on_{var}' for var in on_variables] + [f'phi_ir{ir:d}' for ir in (1, 2, 5, 8)]
     return variables, special
 
 
-def orbit_setup(madx: Madx, accel: str, **kwargs):
+def orbit_setup(madx: Madx, accel: str, year: int = 2018, **kwargs):
     """ Automated orbit setup for some default schemes.
     Please check if these are still valid.
 
     Args:
         madx: Madx instance
         accel (str): 'lhc' or 'hllhc'
+        year (int): year of the models/optics (for 'lhc')
 
     Keyword Args:
         scheme: default orbit scheme to apply.
@@ -134,7 +156,7 @@ def orbit_setup(madx: Madx, accel: str, **kwargs):
         dictionary with current settings of the scheme.
     """
     kwargs = {k.lower(): v for k, v in kwargs.items()}
-    variables, special = get_orbit_variables(accel)
+    variables, special = get_orbit_variables(accel, year)
     scheme_key = kwargs.get('scheme', 'flat')
     mvars = madx.globals
     full_scheme = {}
@@ -168,17 +190,19 @@ def orbit_setup(madx: Madx, accel: str, **kwargs):
     return full_scheme
 
 
-def get_current_orbit_scheme(madx: Madx, accel: str):
+def get_current_orbit_scheme(madx: Madx, accel: str, year: int = 2018):
     """ Get the current values for the orbit variales.
 
     Args:
         madx: Madx instance
+        accel (str): 'lhc' or 'hllhc'
+        year (int): year of the models/optics (for 'lhc')
 
     Returns:
         Dictionary of all orbit variables and their value/definition.
 
     """
-    variables, special = get_orbit_variables(accel)
+    variables, special = get_orbit_variables(accel, year)
     return {var: madx.globals.defs[var] for var in variables + list(special.keys()) if var in madx.globals}
 
 
@@ -207,24 +231,24 @@ def check_crabbing(madx: Madx, auto_set: bool = False):
 # Orbit Checks -----------------------------------------------------------------
 
 
-def log_orbit(madx: Madx, accel: str, twiss: TfsDataFrame = None, ip: Union[Iterable[int], int] = None):
+def log_orbit(madx: Madx, accel: str, year: int = 2018, twiss: TfsDataFrame = None, ip: Union[Iterable[int], int] = None):
     """ Get the orbit from madx-instance and twiss-dataframe and
     log the configuration per IP. """
     if twiss is None:
         twiss = get_tfs(madx.table.twiss, columns=['NAME', 'S', 'X', 'Y', 'PX', 'PY'])
 
-    variables = get_current_orbit_scheme(madx, accel)  # takes a few seconds, so do here
+    variables = get_current_orbit_scheme(madx, accel, year)  # takes a few seconds, so do here
     for ip in _get_ip_iterable(ip):
         log_orbit_from_madx(madx, accel, ip, variables)
         log_orbit_from_twiss(twiss, ip)
 
 
-def log_orbit_from_madx(madx: Madx, accel: str,
+def log_orbit_from_madx(madx: Madx, accel: str, year: int = 2018,
                         ip: Union[Iterable[int], int] = None,
                         variables: Iterable[str] = None):
     """ Log current orbit scheme sorted by IP. """
     if variables is None:
-        variables = get_current_orbit_scheme(madx, accel)
+        variables = get_current_orbit_scheme(madx, accel, year)
 
     for ip in _get_ip_iterable(ip):
         for k, v in variables.items():


### PR DESCRIPTION
- Added:
  - new (>2022) lhc orbit variabes and related changes in corresponding functions
  - flexible knob-suffix instead of pre-defined "_sq"
  - new functions: `temp_disable_errors` and `lhc_arc_names` in `general.py`
  - Coupling knob creation